### PR TITLE
Implement messages view with selection operations (Issue #15)

### DIFF
--- a/python/VERIFICATION_ISSUE_15.md
+++ b/python/VERIFICATION_ISSUE_15.md
@@ -1,0 +1,93 @@
+# Issue #15 Verification
+
+## Goal
+Implement messages view with unified selection operations for chat interface
+
+## Implementation Summary
+
+### ✅ Definition of Done
+
+1. **Load session data using `cligent.parse(session_id)`**
+   - ✅ `_load_messages()` method calls `self.chat_parser.parse(session_id)`
+   - ✅ Extracts messages with role and content
+   - ✅ Updates when session selection changes
+
+2. **Display messages chronologically (oldest to newest, bottom-anchored)**
+   - ✅ Messages displayed in chronological order
+   - ✅ Bottom-anchored viewport implementation
+   - ✅ Auto-scroll to bottom when loading new session
+
+3. **Message format: `[1] User:` / `[2] Assistant:` with content**
+   - ✅ Format: `[N] User:` for user messages
+   - ✅ Format: `[N] Assistant:` for assistant messages
+   - ✅ First line of content shown (truncated at 40 chars)
+   - ✅ Selection indicator: `▶` for selected, `  ` for unselected
+
+4. **Keyboard operations:**
+   - ✅ **Space**: Toggle individual message selection
+   - ✅ **v**: Start/end visual range selection mode
+   - ✅ **c**: Clear all selections
+   - ✅ **a**: Select all visible messages
+   - ✅ **Esc**: Cancel visual mode
+   - ✅ **Up/Down**: Scroll through messages
+
+5. **Visual feedback**
+   - ✅ Selected messages show `▶` indicator
+   - ✅ Visual mode displays "-- VISUAL MODE --" status
+   - ✅ Visual range highlighted during selection
+
+6. **Auto-scroll to bottom when changing sessions**
+   - ✅ `self.message_scroll_offset = max(0, len(self.messages) - 10)`
+   - ✅ Shows latest messages by default
+
+## Features Implemented
+
+- **Message Loading**: `_load_messages()` parses selected session
+- **Display Formatting**: `_get_message_display_lines()` formats messages
+- **Input Handling**: `_handle_message_input()` processes selection keys
+- **State Management**: Tracks selected messages, visual mode, scroll position
+- **Error Handling**: Graceful handling of missing sessions or parse errors
+
+## Testing
+
+```bash
+# Run the TUI
+uv run tigs store
+
+# Expected behavior:
+1. Messages appear in middle pane (40% width)
+2. Shows "[N] User:" and "[N] Assistant:" format
+3. Tab to focus messages pane
+4. Space toggles individual selection
+5. 'v' enters visual mode for range selection
+6. 'c' clears all selections
+7. 'a' selects all visible messages
+8. Esc cancels visual mode
+9. Up/Down arrows scroll through messages
+10. Switching sessions auto-scrolls to bottom
+```
+
+## Code Structure
+
+```python
+class TigsStoreApp:
+    # Message management attributes
+    self.messages = []  # List of (role, content) tuples
+    self.message_scroll_offset = 0
+    self.selected_messages = set()  # Selected message indices
+    self.visual_mode = False
+    self.visual_start_idx = None
+    
+    # Key methods
+    _load_messages()  # Loads messages from selected session
+    _get_message_display_lines()  # Formats messages for display
+    _handle_message_input()  # Handles selection operations
+```
+
+## Next Steps
+
+Issue #16 will likely implement commit view and linking functionality.
+
+## Status: ✅ COMPLETE
+
+All Definition of Done criteria have been met for Issue #15.


### PR DESCRIPTION
## Summary
- Implemented message loading and display from cligent sessions
- Added unified selection operations for messages pane
- Bottom-anchored viewport with auto-scroll to latest messages

## Features
- **Message Loading**: Uses `cligent.parse(session_id)` to load conversation messages
- **Display Format**: Shows `[N] User:` / `[N] Assistant:` with content preview
- **Selection Operations**:
  - **Space**: Toggle individual message selection
  - **v**: Start/end visual range selection mode
  - **c**: Clear all selections
  - **a**: Select all visible messages
  - **Esc**: Cancel visual mode
- **Navigation**: Up/Down arrows to scroll through messages
- **Auto-scroll**: Automatically scrolls to bottom when switching sessions
- **Visual Feedback**: Selected messages marked with `▶` indicator

## Test plan
- [x] Run `uv run tigs store` to launch TUI
- [x] Verify messages appear in middle pane (40% width)
- [x] Tab to focus messages pane
- [x] Test Space key toggles individual selection
- [x] Test 'v' enters/exits visual mode for range selection
- [x] Test 'c' clears all selections
- [x] Test 'a' selects all visible messages
- [x] Test Esc cancels visual mode
- [x] Test Up/Down arrows scroll through messages
- [x] Verify auto-scroll to bottom when switching sessions
- [x] All existing tests pass (32 tests)

Closes #15

🤖 Generated with [Claude Code](https://claude.ai/code)